### PR TITLE
fix page redirect

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,15 @@ const nextConfig = {
       },
     ],
   },
+  async redirects() {
+    return [
+      {
+        source: '/registry',
+        destination: '/agents',
+        permanent: true,
+      },
+    ];
+  },
   experimental: {
     serverComponentsExternalPackages: ['pino', 'pino-pretty'],
   },


### PR DESCRIPTION
`/registry `still be used by some users and now is `/agents`