### PR TITLE
Chat redirect 

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -27,19 +27,26 @@ import { usePathname } from 'next/navigation';
 import { shouldShowHeader } from '@/lib/utils/useShowHeader';
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { useRedirection } from '@/hooks/useRedirection';
 
 const Header = () => {
+  useRedirection();
   const { width } = useWindowSize();
   const isMobile = !!width && width < 1024;
 
   const [isModalOpen, setModalOpen] = useState<boolean>(false);
   const [isConnectModalOpen, setConnectModalOpen] = useState<boolean>(false);
-  const [hasRedirected, setHasRedirected] = useState<boolean>(false);
 
   const { isConnected: isNearConnected, connect } = useBitteWallet();
+  const { isConnected } = useAccount();
 
   const pathname = usePathname();
   const router = useRouter();
+
+  useEffect(() => {
+    // Prefetch the /chat route to make navigation faster
+    router.prefetch('/chat');
+  }, [router]);
 
   const handleSignIn = async () => {
     try {
@@ -48,24 +55,6 @@ const Header = () => {
       console.error('Failed to connect wallet:', error);
     }
   };
-
-  const { isConnected } = useAccount();
-
-  useEffect(() => {
-    router.prefetch('/chat');
-  }, [router]);
-
-  useEffect(() => {
-    if (
-      (isConnected || isNearConnected) &&
-      !pathname.includes('/chat') &&
-      pathname === '/' &&
-      !hasRedirected
-    ) {
-      router.replace('/chat');
-      setHasRedirected(true);
-    }
-  }, [isConnected, isNearConnected, pathname, router, hasRedirected]);
 
   if (!shouldShowHeader(pathname)) {
     return;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -25,6 +25,8 @@ import ManageAccountsDialog from './ManageAccountsDialog';
 import { Button } from '../ui/button';
 import { usePathname } from 'next/navigation';
 import { shouldShowHeader } from '@/lib/utils/useShowHeader';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 
 const Header = () => {
   const { width } = useWindowSize();
@@ -32,10 +34,12 @@ const Header = () => {
 
   const [isModalOpen, setModalOpen] = useState<boolean>(false);
   const [isConnectModalOpen, setConnectModalOpen] = useState<boolean>(false);
+  const [hasRedirected, setHasRedirected] = useState<boolean>(false);
 
   const { isConnected: isNearConnected, connect } = useBitteWallet();
 
   const pathname = usePathname();
+  const router = useRouter();
 
   const handleSignIn = async () => {
     try {
@@ -46,6 +50,22 @@ const Header = () => {
   };
 
   const { isConnected } = useAccount();
+
+  useEffect(() => {
+    router.prefetch('/chat');
+  }, [router]);
+
+  useEffect(() => {
+    if (
+      (isConnected || isNearConnected) &&
+      !pathname.includes('/chat') &&
+      pathname === '/' &&
+      !hasRedirected
+    ) {
+      router.replace('/chat');
+      setHasRedirected(true);
+    }
+  }, [isConnected, isNearConnected, pathname, router, hasRedirected]);
 
   if (!shouldShowHeader(pathname)) {
     return;

--- a/src/hooks/useRedirection.ts
+++ b/src/hooks/useRedirection.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { useBitteWallet } from '@bitte-ai/react';
 import { useAccount } from 'wagmi';
@@ -9,10 +9,6 @@ export const useRedirection = () => {
   const { isConnected, isConnecting } = useAccount();
   const router = useRouter();
   const pathname = usePathname();
-
-  const [hasRedirected, setHasRedirected] = useState<boolean>(
-    localStorage.getItem('hasRedirected') === 'true'
-  );
 
   useEffect(() => {
     const redirected = localStorage.getItem('hasRedirected') === 'true';
@@ -26,7 +22,6 @@ export const useRedirection = () => {
       ) {
         router.replace('/chat');
         localStorage.setItem('hasRedirected', 'true');
-        setHasRedirected(true);
       }
     };
 
@@ -38,7 +33,6 @@ export const useRedirection = () => {
       // Delay the removal of the redirection flag to allow state stabilization
       const timeoutId = setTimeout(() => {
         localStorage.removeItem('hasRedirected');
-        setHasRedirected(false);
       }, 500);
 
       return () => clearTimeout(timeoutId);

--- a/src/hooks/useRedirection.ts
+++ b/src/hooks/useRedirection.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useBitteWallet } from '@bitte-ai/react';
+import { useAccount } from 'wagmi';
+import { usePathname } from 'next/navigation';
+
+export const useRedirection = () => {
+  const { isConnected: isNearConnected } = useBitteWallet();
+  const { isConnected, isConnecting } = useAccount();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const [hasRedirected, setHasRedirected] = useState<boolean>(
+    localStorage.getItem('hasRedirected') === 'true'
+  );
+
+  useEffect(() => {
+    const redirected = localStorage.getItem('hasRedirected') === 'true';
+    const checkAndRedirect = () => {
+      if (
+        (isConnected || isNearConnected) &&
+        !pathname.includes('/chat') &&
+        pathname === '/' &&
+        !redirected &&
+        !isConnecting
+      ) {
+        router.replace('/chat');
+        localStorage.setItem('hasRedirected', 'true');
+        setHasRedirected(true);
+      }
+    };
+
+    checkAndRedirect();
+  }, [isConnected, isNearConnected, pathname, router, isConnecting]);
+
+  useEffect(() => {
+    if (!isConnected && !isNearConnected && !isConnecting && pathname === '/') {
+      // Delay the removal of the redirection flag to allow state stabilization
+      const timeoutId = setTimeout(() => {
+        localStorage.removeItem('hasRedirected');
+        setHasRedirected(false);
+      }, 500);
+
+      return () => clearTimeout(timeoutId);
+    }
+  }, [isConnected, isNearConnected, isConnecting, pathname]);
+};


### PR DESCRIPTION
add Chat route redirect to landingpage if user is connected. 

- using a storage item hook to make sure he will be able to use all the routes again after he got already redirected 
- using .prefetch & .replace to make sure the redirect is fast as possible