### PR TITLE
fix: Run Agent redirect and  selection logic in playground and debug modes

### DIFF
--- a/src/components/layout/ChatContent.tsx
+++ b/src/components/layout/ChatContent.tsx
@@ -48,8 +48,14 @@ const ChatContent = ({
 
     if (value) {
       params.set('mode', AssistantsMode.DEBUG);
+      if (agentData?.agents[0]) {
+        handleSelectAgent(agentData.unverifiedAgents[0]); // Ensure agent is defined before calling
+      }
     } else {
       params.delete('mode');
+      if (agentData?.unverifiedAgents[0]) {
+        handleSelectAgent(agentData.agents[0]); // Ensure agent is defined before calling
+      }
     }
 
     history.replaceState({}, '', `?${params.toString()}`);
@@ -104,15 +110,6 @@ const ChatContent = ({
       }
     }
   }, [agentsList, selectedAgent, agentIdParam]);
-
-  useEffect(() => {
-    if (!agentData) return;
-    if (!isPlayground) {
-      handleSelectAgent(agentData.agents[0]);
-    } else {
-      handleSelectAgent(agentData.unverifiedAgents[0]);
-    }
-  }, [isPlayground, agentData]);
 
   // Debounce saving to sessionStorage to prevent excessive writes
   useEffect(() => {

--- a/src/components/ui/agents/AgentSelector.tsx
+++ b/src/components/ui/agents/AgentSelector.tsx
@@ -78,10 +78,7 @@ export const AgentSelector = ({
                     : agent;
 
                 onSelectAgent(selectedAgent);
-                sessionStorage.setItem(
-                  'selectedselectedAgent',
-                  JSON.stringify(agent)
-                ); // Save to sessionStorage when an agent is selected
+                sessionStorage.setItem('selectedAgent', JSON.stringify(agent)); // Save to sessionStorage when an agent is selected
               }}
               className={cn(
                 'group w-full min-w-[180px] shrink-0 cursor-pointer overflow-hidden rounded-md p-4 border border-transparent',


### PR DESCRIPTION

- Updated ChatContent component to handle agent selection more robustly
- Removed redundant useEffect for initial agent selection
- Fixed sessionStorage key for selected agent in AgentSelector
- Ensured agent selection works correctly when toggling debug mode