### PR TITLE
fix: Correct agent detail route URL generation

### DIFF
--- a/src/components/ui/agents/AgentCard.tsx
+++ b/src/components/ui/agents/AgentCard.tsx
@@ -11,7 +11,7 @@ import { Button } from '../button';
 const AgentCard = ({ agent }: { agent: RegistryData }): JSX.Element | null => {
   const goToAgentDetail = (message: string) => {
     const encodedPrompt = encodeURIComponent(message);
-    return `agents/${agent.id}?prompt=${encodedPrompt}`;
+    return `/agents/${agent.id}?prompt=${encodedPrompt}`;
   };
 
   if (!agent) return null;


### PR DESCRIPTION
Prepended a forward slash to the route path in the goToAgentDetail function to ensure proper URL routing