### PR TITLE
fix: Improve agent image handling in AgentCard and AgentSelector

### DIFF
--- a/src/components/ui/agents/AgentCard.tsx
+++ b/src/components/ui/agents/AgentCard.tsx
@@ -16,7 +16,6 @@ const AgentCard = ({ agent }: { agent: RegistryData }): JSX.Element | null => {
 
   if (!agent) return null;
 
-  console.log({ image: agent.image });
   const coverImage = agent.image
     ? agent.image.startsWith('http')
       ? agent.image

--- a/src/components/ui/agents/AgentCard.tsx
+++ b/src/components/ui/agents/AgentCard.tsx
@@ -15,11 +15,11 @@ const AgentCard = ({ agent }: { agent: RegistryData }): JSX.Element | null => {
   };
 
   if (!agent) return null;
-  const coverImage = agent?.image
+
+  console.log({ image: agent.image });
+  const coverImage = agent.image
     ? agent.image.startsWith('http')
-      ? agent.image === 'http://localhost:3000/aave-agent-logo.png'
-        ? '/aave-agent-logo.png'
-        : agent.image
+      ? agent.image
       : `/${agent.image.replace(/^\//, '')}`
     : '/logo.svg';
 

--- a/src/components/ui/agents/AgentSelector.tsx
+++ b/src/components/ui/agents/AgentSelector.tsx
@@ -90,8 +90,8 @@ export const AgentSelector = ({
               <div className='mb-2 flex items-center justify-between gap-2'>
                 <div className='flex items-center gap-2'>
                   <Image
-                    src={agent?.image || '/bitte-symbol-black.svg'}
-                    className={`object-contain ${!agent?.image ? 'bg-white' : ''}`}
+                    src={agent?.image || '/logo.svg'}
+                    className='object-contain'
                     width={24}
                     height={24}
                     alt={`${agent?.id}-logo`}


### PR DESCRIPTION
- Simplified image path resolution in AgentCard
- Updated AgentSelector to use default '/logo.svg' when no agent image is available
- Removed unnecessary background styling for agent images