### PR TITLE
fix:  update tool component from agent builder to use tool ids instead of index

### DIFF
--- a/src/app/(dashboard)/build-agents/page.tsx
+++ b/src/app/(dashboard)/build-agents/page.tsx
@@ -86,7 +86,6 @@ export default function BuildAgents() {
   }, []);
 
   const toggleSelection = (toolId: string) => {
-    console.log('toggleSelection', toolId);
     setSelectedItems((prev) => {
       const newSet = new Set(prev);
       if (newSet.has(toolId)) {

--- a/src/app/(dashboard)/build-agents/page.tsx
+++ b/src/app/(dashboard)/build-agents/page.tsx
@@ -63,7 +63,7 @@ export default function BuildAgents() {
           />
         ),
         label: tool.function.name,
-        action: () => toggleSelection(tool.id),
+        action: () => toggleSelection(tool.id || tool.function.name),
         metadata: tool.isPrimitive ? 'Primitive' : 'Tool',
       })),
     },

--- a/src/app/(dashboard)/build-agents/page.tsx
+++ b/src/app/(dashboard)/build-agents/page.tsx
@@ -7,6 +7,15 @@ import {
   CommandMenu,
   type CommandMenuGroup,
 } from '@/components/ui/command-menu';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
 import { useFilters } from '@/hooks/useFilters';
 import { Filters as AgentFilters } from '@/lib/types/agent.types';
 import { Tool } from '@/lib/types/tool.types';
@@ -14,20 +23,11 @@ import { filterHandler } from '@/lib/utils/filters';
 import { getCommandKey } from '@/lib/utils/os';
 import { ListFilter } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState, useMemo } from 'react';
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-  DialogFooter,
-  DialogClose,
-} from '@/components/ui/dialog';
+import { useEffect, useMemo, useState } from 'react';
 
 export default function BuildAgents() {
   const router = useRouter();
-  const [selectedItems, setSelectedItems] = useState<Set<number>>(new Set());
+  const [selectedItems, setSelectedItems] = useState<Set<string>>(new Set());
   const [tools, setTools] = useState<Tool[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [selectedFilters, setSelectedFilters] = useState<AgentFilters[]>([]);
@@ -54,7 +54,7 @@ export default function BuildAgents() {
   const groups: CommandMenuGroup[] = [
     {
       heading: 'Tools',
-      items: tools.map((tool, index) => ({
+      items: tools.map((tool) => ({
         icon: (
           <img
             src={tool?.image || 'bitte-symbol-black.svg'}
@@ -63,7 +63,7 @@ export default function BuildAgents() {
           />
         ),
         label: tool.function.name,
-        action: () => toggleSelection(index),
+        action: () => toggleSelection(tool.id),
         metadata: tool.isPrimitive ? 'Primitive' : 'Tool',
       })),
     },
@@ -85,13 +85,14 @@ export default function BuildAgents() {
     fetchTools();
   }, []);
 
-  const toggleSelection = (index: number) => {
+  const toggleSelection = (toolId: string) => {
+    console.log('toggleSelection', toolId);
     setSelectedItems((prev) => {
       const newSet = new Set(prev);
-      if (newSet.has(index)) {
-        newSet.delete(index);
+      if (newSet.has(toolId)) {
+        newSet.delete(toolId);
       } else {
-        newSet.add(index);
+        newSet.add(toolId);
       }
       return newSet;
     });
@@ -99,8 +100,8 @@ export default function BuildAgents() {
 
   const handleNextStep = () => {
     router.prefetch('/build-agents/config');
-    const selectedToolsData = Array.from(selectedItems).map(
-      (index) => tools[index]
+    const selectedToolsData = Array.from(selectedItems).map((toolId) =>
+      tools.find((tool) => tool.id === toolId)
     );
     localStorage.setItem('selectedTools', JSON.stringify(selectedToolsData));
     router.push('/build-agents/config');

--- a/src/components/ToolGrid.tsx
+++ b/src/components/ToolGrid.tsx
@@ -1,14 +1,14 @@
+import InfoTooltip from '@/components/ui/InfoTooltip';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tool } from '@/lib/types/tool.types';
-import Image from 'next/image';
 import { mapChainIdsToNetworks } from '@/lib/utils/chainIds';
-import InfoTooltip from '@/components/ui/InfoTooltip';
-import { useEffect, useState, useRef } from 'react';
+import Image from 'next/image';
+import { useEffect, useRef, useState } from 'react';
 
 interface ToolGridProps {
   tools: Tool[];
-  selectedItems: Set<number>;
-  toggleSelection: (index: number) => void;
+  selectedItems: Set<string>;
+  toggleSelection: (toolId: string) => void;
   loading: boolean;
 }
 
@@ -109,18 +109,20 @@ export function ToolGrid({
 
   return (
     <div className='grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6 md:pb-0 pb-24 auto-rows-fr'>
-      {tools.map((tool, index) => {
+      {tools.map((tool: Tool, index: number) => {
         const networks = mapChainIdsToNetworks(tool.chainIds || [], true);
         const visibleCount = visiblePillCounts[index] || 1;
         const visibleNetworks = networks.slice(0, visibleCount);
         const remainingCount = networks.length - visibleCount;
 
+        const id = tool.id || tool.function.name;
+
         return (
           <div
             key={index}
-            onClick={() => toggleSelection(index)}
+            onClick={() => toggleSelection(id)}
             className={`p-4 text-left rounded-md min-h-[125px] cursor-pointer flex flex-col border ${
-              selectedItems.has(index)
+              selectedItems.has(id)
                 ? 'bg-mb-purple-20 border-mb-purple'
                 : 'bg-mb-black-50 border-mb-black-50 hover:border-mb-purple'
             }`}


### PR DESCRIPTION

- Changed selectedItems state type from Set<number> to Set<string> to accommodate tool IDs.
- Updated toggleSelection function to use tool IDs instead of index.
- Modified ToolGrid component to handle tool selection based on IDs, improving consistency and clarity in selection logic.