### PR TITLE
feat: add MCP section to sidebar and update header/footer visibility …

### DIFF
--- a/src/app/(dashboard)/mcp/[id]/page.tsx
+++ b/src/app/(dashboard)/mcp/[id]/page.tsx
@@ -1,0 +1,5 @@
+const ChatPage = async () => {
+  return <>MCP</>;
+};
+
+export default ChatPage;

--- a/src/app/(dashboard)/mcp/page.tsx
+++ b/src/app/(dashboard)/mcp/page.tsx
@@ -1,0 +1,5 @@
+const ChatPage = async () => {
+  return <>MCP</>;
+};
+
+export default ChatPage;

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -1,4 +1,10 @@
-import { ArrowUpRight, Bot, TerminalSquare, Hammer } from 'lucide-react';
+import {
+  ArrowUpRight,
+  Bot,
+  TerminalSquare,
+  Hammer,
+  Server,
+} from 'lucide-react';
 import * as React from 'react';
 
 import { NavLinks } from '@/components/nav-links';
@@ -51,6 +57,12 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         url: '/build-agents',
         icon: Hammer,
         isActive: pathname.startsWith('/build-agents'),
+      },
+      {
+        title: 'MCP (beta)',
+        url: `/mcp/${generateId()}`,
+        icon: Server,
+        isActive: pathname.startsWith('/mcp'),
       },
     ],
     links: [

--- a/src/lib/utils/useShowHeader.ts
+++ b/src/lib/utils/useShowHeader.ts
@@ -1,10 +1,10 @@
 // Utility function to determine if the header should be shown
 export function shouldShowHeader(pathname: string): boolean {
-  const noHeaderRoutes = ['/chat', '/agents', '/build-agents'];
+  const noHeaderRoutes = ['/chat', '/agents', '/build-agents', '/mcp'];
   return !noHeaderRoutes.some((route) => pathname.startsWith(route));
 }
 
 export function shouldShowFooter(pathname: string): boolean {
-  const noFooterRoutes = ['/chat', '/agents', '/build-agents'];
+  const noFooterRoutes = ['/chat', '/agents', '/build-agents', '/mcp'];
   return !noFooterRoutes.some((route) => pathname.startsWith(route));
 }


### PR DESCRIPTION
…logic

- Introduced a new MCP (beta) link in the AppSidebar with a Server icon.
- Updated the shouldShowHeader and shouldShowFooter utility functions to include '/mcp' in the list of routes that do not display the header and footer.