### PR TITLE
fix: prevent NaN error in Daily Average calculation agent detail

### DIFF
--- a/src/components/layout/AgentDetail.tsx
+++ b/src/components/layout/AgentDetail.tsx
@@ -86,12 +86,14 @@ export const AgentDetailComponent = ({
                       Daily Average
                     </div>
                     <div className='text-2xl font-bold text-white'>
-                      {Math.round(
-                        Object.values(pings).reduce(
-                          (sum, count) => sum + count,
-                          0
-                        ) / Object.keys(pings).length
-                      )}
+                      {pings && Object.keys(pings).length > 0
+                        ? Math.round(
+                            Object.values(pings).reduce(
+                              (sum, count) => sum + count,
+                              0
+                            ) / Object.keys(pings).length
+                          )
+                        : 0}
                     </div>
                   </CardContent>
                 </Card>


### PR DESCRIPTION
- Added a check to ensure pings are present and not empty before calculating the Daily Average, preventing potential division by zero errors.

![IMG_2413](https://github.com/user-attachments/assets/3d4c0b1f-442e-4ef4-88d5-79640c489f21)
