### PR TITLE
persists wallet state server side, adds useWalletConnection for all chain connections

### DIFF
--- a/src/app/(dashboard)/agents/page.tsx
+++ b/src/app/(dashboard)/agents/page.tsx
@@ -1,5 +1,22 @@
 import AgentContent from '@/components/layout/AgentsContent';
+import { cookies } from 'next/headers';
 
 export default async function Agents() {
+  const cookieStore = cookies();
+  const walletState = cookieStore.get('wallet_state')?.value;
+
+  if (!walletState) {
+    return <div>Please connect your wallet to view agents</div>;
+  }
+
+  const state = JSON.parse(walletState);
+  if (
+    !state.isEvmConnected &&
+    !state.isNearConnected &&
+    !state.isSuiConnected
+  ) {
+    return <div>Please connect your wallet to view agents</div>;
+  }
+
   return <AgentContent />;
 }

--- a/src/app/api/wallet/route.ts
+++ b/src/app/api/wallet/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  WalletConnectionState,
+  WalletConnectionResponse,
+} from '@/lib/types/wallet.types';
+
+// In-memory store for demo purposes. In production, use a database
+let walletState: WalletConnectionState = {
+  isEvmConnected: false,
+  isNearConnected: false,
+  isSuiConnected: false,
+  lastUpdated: new Date().toISOString(),
+};
+
+export async function GET(request: NextRequest) {
+  // Try to get state from cookie first
+  const cookieState = request.cookies.get('wallet_state')?.value;
+  if (cookieState) {
+    try {
+      const state = JSON.parse(cookieState);
+      return NextResponse.json<WalletConnectionResponse>({
+        success: true,
+        state,
+      });
+    } catch (error) {
+      console.error('Error parsing cookie state:', error);
+    }
+  }
+
+  return NextResponse.json<WalletConnectionResponse>({
+    success: true,
+    state: walletState,
+  });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const newState: WalletConnectionState = {
+      ...body,
+      lastUpdated: new Date().toISOString(),
+    };
+
+    walletState = newState;
+
+    const response = NextResponse.json<WalletConnectionResponse>({
+      success: true,
+      state: walletState,
+    });
+
+    // Set cookie with wallet state
+    response.cookies.set('wallet_state', JSON.stringify(walletState), {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      maxAge: 30 * 24 * 60 * 60, // 30 days
+      path: '/',
+      domain:
+        process.env.NODE_ENV === 'production'
+          ? process.env.NEXT_PUBLIC_DOMAIN
+          : 'localhost',
+    });
+
+    return response;
+  } catch (error) {
+    return NextResponse.json<WalletConnectionResponse>(
+      {
+        success: false,
+        state: walletState,
+        error: 'Failed to update wallet state',
+      },
+      { status: 400 }
+    );
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
-import { headers } from 'next/headers';
+import { headers, cookies } from 'next/headers';
 import NextTopLoader from 'nextjs-toploader';
 
 import '@/app/styles/globals.css';
@@ -51,7 +51,16 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const cookies = headers().get('wagmi');
+  const wagmiCookies = headers().get('wagmi');
+  const cookieStore = cookies();
+  const walletState = cookieStore.get('wallet_state')?.value;
+  const decodedState = walletState ? decodeURIComponent(walletState) : null;
+  const parsedState = decodedState ? JSON.parse(decodedState) : null;
+  const isConnected =
+    parsedState?.isEvmConnected ||
+    parsedState?.isNearConnected ||
+    parsedState?.isSuiConnected;
+
   return (
     <html lang='en' className='overflow-x-hidden'>
       <head>
@@ -61,10 +70,10 @@ export default function RootLayout({
         />
       </head>
       <body className={`${inter.className} dark bg-black`}>
-        <Providers cookies={cookies}>
-          <Header />
+        <Providers cookies={wagmiCookies}>
+          {!isConnected && <Header />}
           {children}
-          <Footer />
+          {!isConnected && <Footer />}
           <Analytics />
           <NextTopLoader color='#334155' showSpinner={false} height={4} />
           <SpeedInsights />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,31 @@
+import AgentContent from '@/components/layout/AgentsContent';
 import { HomeComponent } from '@/components/layout/Home';
 import NewHero from '@/components/layout/NewHero';
+import { cookies } from 'next/headers';
+import RootSidebar from '@/components/root-sidebar';
 
 export default async function Home() {
+  const cookieStore = cookies();
+  const walletState = cookieStore.get('wallet_state')?.value;
+  const decodedState = walletState ? decodeURIComponent(walletState) : null;
+  const parsedState = decodedState ? JSON.parse(decodedState) : null;
+  const isConnected =
+    parsedState?.isEvmConnected ||
+    parsedState?.isNearConnected ||
+    parsedState?.isSuiConnected;
+
+  if (isConnected) {
+    return (
+      <RootSidebar>
+        <AgentContent />
+      </RootSidebar>
+    );
+  }
+
   return (
     <main className='flex flex-col items-center justify-between'>
       <NewHero />
-      <HomeComponent />
+      <HomeComponent initialWalletState={parsedState} />
     </main>
   );
 }

--- a/src/components/layout/AiChat.tsx
+++ b/src/components/layout/AiChat.tsx
@@ -3,12 +3,13 @@
 'use client';
 
 import { useIsClient } from '@/hooks/useIsClient';
+import { useWalletConnection } from '@/hooks/useWalletConnection';
 import { RegistryData } from '@/lib/types/agent.types';
 import { BitteAiChat } from '@bitte-ai/chat';
 import { useBitteWallet, Wallet } from '@bitte-ai/react';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
-import { useAccount, useSendTransaction, useSwitchChain } from 'wagmi';
+import { useSendTransaction, useSwitchChain } from 'wagmi';
 import ConnectDialog from './ConnectDialog';
 import CustomChatSendButton from './CustomChatSendBtn';
 import { useWallet as useSuiWallet } from '@suiet/wallet-kit';
@@ -37,15 +38,16 @@ const AiChat = ({
   const [isConnectModalOpen, setConnectModalOpen] = useState<boolean>(false);
   const [wallet, setWallet] = useState<Wallet | undefined>(undefined);
   const suiWallet = useSuiWallet();
-  const { address, isConnected: isEvmConnected } = useAccount();
   const { data: hash, sendTransaction } = useSendTransaction();
   const { switchChain } = useSwitchChain();
 
   const { selector, isConnected, isWalletSelectorSetup } = useBitteWallet();
+  const { isEvmConnected, isNearConnected, isSuiConnected, isLoading } =
+    useWalletConnection();
 
   const isClient = useIsClient();
   const isWalletDisconnected =
-    !isEvmConnected && !isConnected && !suiWallet.connected;
+    !isEvmConnected && !isNearConnected && !isSuiConnected;
 
   useEffect(() => {
     if (!selector) {
@@ -74,6 +76,10 @@ const AiChat = ({
 
     fetchWallet();
   }, [selector, isConnected, isWalletSelectorSetup]);
+
+  if (isLoading) {
+    return null; // Or a loading spinner
+  }
 
   return (
     isClient && (
@@ -116,7 +122,7 @@ const AiChat = ({
           evm: {
             sendTransaction,
             switchChain,
-            address,
+            address: isEvmConnected ? undefined : undefined,
             hash,
           },
           sui: {

--- a/src/components/layout/Home.tsx
+++ b/src/components/layout/Home.tsx
@@ -8,6 +8,7 @@ import { MB_URL } from '@/lib/url';
 import { ProductCardsSection } from './ProductCardsSection';
 import { SupportedChainsSection } from './SupportedChainsSection';
 import TextSection from './TextSection';
+import { WalletConnectionState } from '@/lib/types/wallet.types';
 
 import dynamic from 'next/dynamic';
 
@@ -51,7 +52,11 @@ const crossSection = {
   isDisabled: false,
 };
 
-export const HomeComponent = () => {
+interface HomeComponentProps {
+  initialWalletState: WalletConnectionState | null;
+}
+
+export const HomeComponent: React.FC<HomeComponentProps> = () => {
   return (
     <>
       <SupportedChainsSection />

--- a/src/components/layout/NearWalletSelector.tsx
+++ b/src/components/layout/NearWalletSelector.tsx
@@ -25,6 +25,9 @@ export const NearWalletConnector = ({
   const handleSignIn = async () => {
     try {
       await connect();
+      setTimeout(() => {
+        window.dispatchEvent(new Event('walletStateChanged'));
+      }, 500);
     } catch (error) {
       console.error('Failed to connect wallet:', error);
     }

--- a/src/components/layout/SuiWalletConnector.tsx
+++ b/src/components/layout/SuiWalletConnector.tsx
@@ -42,6 +42,10 @@ export const SuiWalletConnector: React.FC<WalletConnectorProps> = ({
       select(walletName);
       setShowWalletModal(false);
       setConnectModalOpen?.(false);
+      // Force a state update after a short delay to ensure the connection is complete
+      setTimeout(() => {
+        window.dispatchEvent(new Event('walletStateChanged'));
+      }, 500);
     } catch (error) {
       console.error('Failed to connect to wallet:', error);
       setConnectionError(

--- a/src/hooks/useWalletConnection.ts
+++ b/src/hooks/useWalletConnection.ts
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react';
+import { useAccount } from 'wagmi';
+import { useBitteWallet } from '@bitte-ai/react';
+import { useWallet as useSuiWallet } from '@suiet/wallet-kit';
+import { WalletConnectionState } from '@/lib/types/wallet.types';
+
+export const useWalletConnection = () => {
+  const [isLoading, setIsLoading] = useState(true);
+  const [serverState, setServerState] = useState<WalletConnectionState | null>(
+    null
+  );
+
+  // Get wallet states from different providers
+  const { address: evmAddress, isConnected: isEvmConnected } = useAccount();
+  const { isConnected: isNearConnected, activeAccountId: nearAddress } =
+    useBitteWallet();
+  const { connected: isSuiConnected, account: suiAccount } = useSuiWallet();
+
+  // Fetch initial state from server
+  useEffect(() => {
+    const fetchState = async () => {
+      try {
+        const response = await fetch('/api/wallet');
+        const data = await response.json();
+        if (data.success) {
+          setServerState(data.state);
+        }
+      } catch (error) {
+        console.error('Failed to fetch wallet state:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchState();
+  }, []);
+
+  // Update server state when wallet connections change
+  useEffect(() => {
+    const updateState = async () => {
+      const newState: WalletConnectionState = {
+        isEvmConnected,
+        isNearConnected,
+        isSuiConnected,
+        evmAddress,
+        nearAddress: nearAddress || undefined,
+        suiAddress: suiAccount?.address || undefined,
+        lastUpdated: new Date().toISOString(),
+      };
+
+      try {
+        const response = await fetch('/api/wallet', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(newState),
+          credentials: 'include', // Ensure cookies are sent with the request
+        });
+
+        const data = await response.json();
+        if (data.success) {
+          setServerState(data.state);
+        }
+      } catch (error) {
+        console.error('Failed to update wallet state:', error);
+      }
+    };
+
+    // Update state immediately when any wallet connection changes
+    updateState();
+  }, [
+    isEvmConnected,
+    isNearConnected,
+    isSuiConnected,
+    evmAddress,
+    nearAddress,
+    suiAccount?.address,
+  ]);
+
+  return {
+    isLoading,
+    serverState,
+    isEvmConnected,
+    isNearConnected,
+    isSuiConnected,
+    evmAddress,
+    nearAddress: nearAddress || undefined,
+    suiAddress: suiAccount?.address || undefined,
+  };
+};

--- a/src/lib/types/wallet.types.ts
+++ b/src/lib/types/wallet.types.ts
@@ -1,0 +1,15 @@
+export interface WalletConnectionState {
+  isEvmConnected: boolean;
+  isNearConnected: boolean;
+  isSuiConnected: boolean;
+  evmAddress?: string;
+  nearAddress?: string;
+  suiAddress?: string;
+  lastUpdated: string;
+}
+
+export interface WalletConnectionResponse {
+  success: boolean;
+  state: WalletConnectionState;
+  error?: string;
+}


### PR DESCRIPTION
- adds new centralized useWalletConnection for all connections
- adds server side wallet session persistance for handling several pages
- make the agent directory the main page if user is connected ( hides the landing page) 