### PR TITLE
feat: add introduction documentation link and update sidebar links

### DIFF
--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -86,6 +86,12 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     links: [
       {
         name: 'Documentation',
+        url: MB_URL.INTRO_DOCS,
+
+        icon: ArrowUpRight,
+      },
+      {
+        name: 'Build Agent from Scratch',
         url: MB_URL.DEV_DOCS,
         icon: ArrowUpRight,
       },

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -23,6 +23,7 @@ export const MB_URL = {
   MINTBASE_LINKEDIN: 'https://www.linkedin.com/company/bitteprotocol',
   MINTBASE_GITHUB: 'https://github.com/BitteProtocol',
   DEV_DOCS: 'https://docs.bitte.ai/agents/quick-start',
+  INTRO_DOCS: 'https://docs.bitte.ai/agents/introduction',
   AI_DOCS: 'https://docs.bitte.ai',
   BOUNTY: 'https://templates.mintbase.xyz/bounty',
   INDEXER_DOCS: 'https://docs.mintbase.xyz/dev/mintbase-graph',


### PR DESCRIPTION
- Added a new link for 'Introduction Documentation' in the AppSidebar.
- Updated the URL constants to include the new introduction documentation link.
- Ensured 'My Agents' link remains active based on the current pathname.